### PR TITLE
Archive this repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+Note: We moved the repo to [the NixOS org](https://github.com/nixos/gsoc) in an effort of making our GSoC participation more official.
+
+---
+
 # GSoC projects
 
 This repo is used to coordinate efforts around the [Google Summer of Code][1] (GSoC) program in the Nix community.


### PR DESCRIPTION
We ended up with a second repository after discussion in [nixos/foundation#115](https://github.com/NixOS/foundation/issues/115#issuecomment-1920777417).
~~I'm aware that the link to the new repo is currently broken, the current link is https://github.com/nixos/gsoc2024 we still have to rename the repo.~~ that's done

Sorry for all the duplicate effort that went into this, I wasn't aware of this repo nor of the discussion in https://discourse.nixos.org/t/google-summer-of-code-2019/1703 and https://discourse.nixos.org/t/google-summer-of-code-2020/5421